### PR TITLE
Fail combine-tests on upstream failure

### DIFF
--- a/.github/workflows/verify-pull-request.yml
+++ b/.github/workflows/verify-pull-request.yml
@@ -54,7 +54,17 @@ jobs:
       - front-end-test
     runs-on: ubuntu-latest
     permissions: {}
-    if: always() && (needs.back-end-test.result == 'success' || needs.back-end-test.result == 'skipped') && (needs.front-end-test.result == 'success' || needs.front-end-test.result == 'skipped')
+    # Must always run so that, when set as a required check, a skipped upstream
+    # failure cannot be treated as a passing required check by branch protection.
+    if: always()
     steps:
-      - name: Finish test
-        run: echo "All tests passed"
+      - name: Verify upstream
+        run: |
+          be='${{ needs.back-end-test.result }}'
+          fe='${{ needs.front-end-test.result }}'
+          if [[ "$be" != "success" && "$be" != "skipped" ]] || \
+             [[ "$fe" != "success" && "$fe" != "skipped" ]]; then
+            echo "Tests failed: back-end=$be, front-end=$fe"
+            exit 1
+          fi
+          echo "All tests passed"


### PR DESCRIPTION
## Summary

`combine-tests` had `if: always() && (... == 'success' || ... == 'skipped')`. When `back-end-test` failed, the condition went false and the job was **skipped** — and GitHub treats a skipped required check as passing. Auto-merge then proceeded on broken PRs.

Fix: always run the job, and have it exit non-zero when an upstream result isn't `success`/`skipped`. The required check now genuinely reflects test outcome.

## Test plan

- [ ] Open a PR with an intentional back-end test failure; confirm `combine-tests` runs and fails.
- [ ] Open a Renovate-style sbt-only PR with green tests; confirm `combine-tests` runs and passes.