### PR TITLE
Fix Renovate setup

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,10 +4,10 @@
     "config:recommended",
     "helpers:pinGitHubActionDigests"
   ],
-  "schedule": ["before 06:00 on monday"],
+  "schedule": ["before 08:00 on monday"],
   "timezone": "Europe/Berlin",
   "prHourlyLimit": 0,
-  "prConcurrentLimit": 0,
+  "prConcurrentLimit": 20,
   "branchConcurrentLimit": 0,
   "packageRules": [
     {


### PR DESCRIPTION
Widen the weekly Renovate schedule window and cap concurrent open PRs at 20 so updates flow without flooding.