### PR TITLE
Pin scalacheck-shapeless_1.15

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,10 @@
       "allowedVersions": "< 3.0.0"
     },
     {
+      "matchPackageNames": ["com.github.alexarchambault:scalacheck-shapeless_1.15"],
+      "allowedVersions": "<1.4.0"
+    },
+    {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["postgres"],
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
Cap scalacheck-shapeless_1.15 below 1.4.0 so Renovate stops proposing the non-existent 1.12.1 leaked from the legacy artifact naming.